### PR TITLE
Remove bullet mentioning removal of findin

### DIFF
--- a/Find.md
+++ b/Find.md
@@ -173,9 +173,6 @@ exist in the current API.
 Other issues are more localized and can be fixed one by one, depending on the chosen general
 plan.
 
-- **`findin`**: This function is just a shorthand for `find(x -> x in c, A)`. It may not be
-needed now that anonymous functions are fast.
-
 - **`findmin` and `findmax`**: `findmin` and `findmax` are inconsistent
 with both proposals, since they return an `(index, value)` tuple instead of an index. They
 should be changed to return an index (as in both proposals above). A new name needs to be


### PR DESCRIPTION
Algorithmic complexity considerations are important for the `find` family
of functions in general but for this function in particular. The complexity
of the current implementation `findin` O(m + n) on average with a fairly
large constant. The suggested alternative would have a complexity of O(m*n).