### PR TITLE
Adds a `Table of Contents` to the `.md` for JULEP3

### DIFF
--- a/Pkg3.md
+++ b/Pkg3.md
@@ -9,6 +9,43 @@
 
 Pkg3 is the working name for a next-generation replacement for Julia's built-in package manager, the current version of which is unofficially known as Pkg2 (introduced in Julia 0.2 to replace the original Pkg1).
 
+### Table of Contents
+- [JULEP 3](#julep-3)
+  - [Abstract](#abstract)
+  - [Rationale](#rationale)
+  - [Depots](#depots)
+  - [Immutability](#immutability)
+  - [Environments](#environments)
+    - [Using Environments](#using-environments)
+    - [Project Environments](#project-environments)
+  - [Packages](#packages)
+  - [Registries](#registries)
+  - [Versions & Compatibility](#versions--compatibility)
+  - [Configuration](#configuration)
+    - [Configuration Fragments](#configuration-fragments)
+      - [Package metadata](#package-metadata)
+      - [Version metadata](#version-metadata)
+      - [Compatibility](#compatibility)
+      - [Runtime Configuration](#runtime-configuration)
+      - [Manifest](#manifest)
+    - [Source Package File](#source-package-file)
+    - [Registry Package File](#registry-package-file)
+  - [Operations](#operations)
+    - [Adding packages](#adding-packages)
+      - [Synopsis](#synopsis)
+      - [Example](#example)
+      - [Pseudo-code](#pseudo-code)
+      - [Dependency fixing](#dependency-fixing)
+      - [Questions](#questions)
+    - [Removing packages](#removing-packages)
+      - [Synopsis](#synopsis)
+      - [Example](#example)
+      - [Pseudo-code](#pseudo-code)
+    - [Updating & upgrading packages](#updating--upgrading-packages)
+      - [Synopsis](#synopsis)
+      - [Examples](#examples)
+      - [Pseudo-code](#pseudo-code)
+
 ## Rationale
 
 There are a number of issues with the design of Pkg2, which necessitate a redesign and replacement:


### PR DESCRIPTION
The Pkg3.md document is very big, and I wasn't sure how to get a feel for what all the content was. I think a ToC helps a lot with that.

I autogenerated this Table of Contents by copy-pasting the content of Pkg3.md into https://tableofcontents.herokuapp.com/.

@StefanKarpinski  Feel free to just say "no, this is silly" to this PR! :)